### PR TITLE
compatibility update node-watch 0.5.x

### DIFF
--- a/libs/website.js
+++ b/libs/website.js
@@ -95,13 +95,13 @@ module.exports = function(logger){
     };
 
 
-    //If an html file was changed reload it
-    watch('website', function(filename){
+    // if an html file was changed reload it
+    /* requires node-watch 0.5.0 or newer */
+    watch(['./website', './website/pages'], function(evt, filename){
         var basename = path.basename(filename);
         if (basename in pageFiles){
-            console.log(filename);
             readPageFiles([basename]);
-            logger.debug(logSystem, 'Server', 'Reloaded file ' + basename);
+            logger.special(logSystem, 'Server', 'Reloaded file ' + basename);
         }
     });
 


### PR DESCRIPTION
Solve https://github.com/z-classic/z-nomp/issues/118 for new installs.
Requires updating older node-watch 0.4.x to 0.5.x from older installs in node_modules
Older installations may need to run `npm update` to update node-watch.