### PR TITLE
Improvements to Shielding Process

### DIFF
--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -239,7 +239,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
     function sendTToZ (callback, tBalance) {
         if (callback === true)
             return;
-        if ((tBalance - 10000) < 0)
+        if ((tBalance - 10000) <= 0)
             return;
 
         // do not allow more than a single z_sendmany operation at a time
@@ -272,7 +272,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
     function sendZToT (callback, zBalance) {
         if (callback === true)
             return;
-        if ((zBalance - 10000) < 0)
+        if ((zBalance - 10000) <= 0)
             return;
 
         // do not allow more than a single z_sendmany operation at a time

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -239,6 +239,10 @@ function SetupForPool(logger, poolOptions, setupFinished){
     function sendTToZ (callback, tBalance) {
         if (callback === true)
             return;
+        if (!tBalance || tBalance === NaN) {
+            logger.error(logSystem, logComponent, 'tBalance === NaN for sendTToZ');
+            return;
+        }
         if ((tBalance - 10000) <= 0)
             return;
 
@@ -272,6 +276,10 @@ function SetupForPool(logger, poolOptions, setupFinished){
     function sendZToT (callback, zBalance) {
         if (callback === true)
             return;
+        if (!zBalance || zBalance === NaN) {
+            logger.error(logSystem, logComponent, 'zBalance === NaN for sendZToT');
+            return;
+        }
         if ((zBalance - 10000) <= 0)
             return;
 

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -453,8 +453,13 @@ function SetupForPool(logger, poolOptions, setupFinished){
                         }
                     }
                 });
+                // if there are no pending operations
                 if (batchRPC.length <= 0) {
                     opidInterval = setInterval(checkOpids, opid_interval);
+                    if (opidCount > 0) {
+                        opidCount = 0;
+                        logger.warning(logSystem, logComponent, 'Cleared opidCount, batchRPC.length <= 0 for z_getoperationresult RPC call.');
+                    }
                     return;
                 }
                 daemon.batchCmd(batchRPC, function(error, results){
@@ -478,6 +483,10 @@ function SetupForPool(logger, poolOptions, setupFinished){
                 checkOpIdSuccessAndGetResult(result.response);
               } else {
                 opidInterval = setInterval(checkOpids, opid_interval);
+                if (opidCount > 0) {
+                    opidCount = 0;
+                    logger.warning(logSystem, logComponent, 'Cleared opidCount, no response from z_getoperationstatus RPC call.');
+                }
               }
             }, true, true);
         }

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -217,7 +217,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
     // get z_address coinbalance
     function listUnspentZ (addr, minConf, displayBool, callback) {
         daemon.cmd('z_getbalance', [addr, minConf], function (result) {
-            if (!result || result.error || result[0].error || !result[0].response) {
+            if (!result || result.error || result[0].error) {
                 logger.error(logSystem, logComponent, 'Error trying to get z-addr balance with RPC call z_getbalance.');
                 callback = function (){};
                 callback(true);

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -182,7 +182,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
     }
     
     //get t_address coinbalance
-    function listUnspent(addr, notAddr, minConf, displayBool, callback) {
+    function listUnspent (addr, notAddr, minConf, displayBool, callback) {
         if (addr !== null) {
             var args = [minConf, 99999999, [addr]];
         } else {
@@ -190,9 +190,8 @@ function SetupForPool(logger, poolOptions, setupFinished){
             var args = [minConf, 99999999];
         }
         daemon.cmd('listunspent', args, function (result) {
-            //Check if payments failed because wallet doesn't have enough coins to pay for tx fees
-            if (!result || result.error) {
-                logger.error(logSystem, logComponent, 'Error trying to get balance for address '+addr+' with RPC listunspent.'
+            if (!result || result.error || result[0].error || !result[0].response) {
+                logger.error(logSystem, logComponent, 'Error trying to get balance for address '+addr+' with RPC call listunspent.'
                     + JSON.stringify(result.error));
                 callback = function (){};
                 callback(true);
@@ -218,9 +217,8 @@ function SetupForPool(logger, poolOptions, setupFinished){
     // get z_address coinbalance
     function listUnspentZ (addr, minConf, displayBool, callback) {
         daemon.cmd('z_getbalance', [addr, minConf], function (result) {
-            //Check if payments failed because wallet doesn't have enough coins to pay for tx fees
-            if (result[0].error) {
-                logger.error(logSystem, logComponent, 'Error trying to get z-addr balance with RPC z_getbalance.' + JSON.stringify(result[0].error));
+            if (!result || result.error || result[0].error || !result[0].response) {
+                logger.error(logSystem, logComponent, 'Error trying to get z-addr balance with RPC call z_getbalance.');
                 callback = function (){};
                 callback(true);
             }

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -207,7 +207,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
                     tBalance = coinsRound(tBalance);
                 }
                 if (displayBool === true) {
-                    logger.special(logSystem, logComponent, addr+' balance of ' + satoshisToCoins(tBalance));
+                    logger.special(logSystem, logComponent, addr+' balance of ' + tBalance);
                 }
                 callback(null, coinsToSatoshies(tBalance));
             }

--- a/libs/paymentProcessor.js
+++ b/libs/paymentProcessor.js
@@ -239,7 +239,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
     function sendTToZ (callback, tBalance) {
         if (callback === true)
             return;
-        if (!tBalance || tBalance === NaN) {
+        if (tBalance === NaN) {
             logger.error(logSystem, logComponent, 'tBalance === NaN for sendTToZ');
             return;
         }
@@ -276,7 +276,7 @@ function SetupForPool(logger, poolOptions, setupFinished){
     function sendZToT (callback, zBalance) {
         if (callback === true)
             return;
-        if (!zBalance || zBalance === NaN) {
+        if (zBalance === NaN) {
             logger.error(logSystem, logComponent, 'zBalance === NaN for sendZToT');
             return;
         }


### PR DESCRIPTION
Potentially resolve issue: https://github.com/z-classic/z-nomp/issues/146
New console message: `Cleared opidCount,...` can be seen when recover from above issue.

Shielding Process Tip: `walletInterval` in pool_config is the shielding process interval. It is important this be set to a larger time than it takes for your CPU to perform `z_sendmany` operations. There is a console message to warn about this: `Increase walletInterval in pool_config...`

 * Improved balance rounding and conversions for listUnspent and listUnspentZ
 * Extra error detection in RPC callback for listUnspent and listUnspentZ
 * Do not process balances equal to or less than fee in sendTToZ and sendZToT
 * Clear opidCount when daemon reports no operations in progress.
 * Default paymentInterval to 3 minutes if missing from pool config.
 * Warn users on paymentInterval less than 3 minutes.
 * Force paymentInterval no less than 1 minute to reduce RPC work queue.
 * Default walletInterval to 1 minute if missing from pool config.
 * Force walletInterval no less than 1 minute to reduce RPC work queue.