### PR TITLE
Add example nginx config

### DIFF
--- a/examples/example_nginx
+++ b/examples/example_nginx
@@ -1,0 +1,19 @@
+server {
+	listen 80;
+
+	root /var/www/html;
+
+	index index.html index.htm index.nginx-debian.html;
+
+	location / {
+		try_files $uri $uri/ =404;
+	}
+
+	location ~ .$ {
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_set_header Host $host;
+		proxy_pass http://127.0.0.1:8080;
+	}
+
+}


### PR DESCRIPTION
I have seen a lot of issues filed for users who want to forward port 80 to 8080 to serve z-nomp via nginx. Here is an example config that will do that assuming the default z-nomp port 8080.