### PR TITLE
live_stats event removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Zcash® and Zclassic - Node Open Mining Portal
+# BTCPrivate - Node Open Mining Portal
 
-**[Click here for the official - Zcash® and Zclassic Stratum Mining Pool Installation Guide](https://zdeveloper.org/wiki:z-nomp_install)**
+**[Click here for the official - z-nomp Stratum Mining Pool Installation Guide](https://zdeveloper.org/wiki:z-nomp_install)**
 
 This is a Equihash mining pool based off of Node Open Mining Portal.
 
@@ -21,19 +21,11 @@ IRC
 
 If your pool uses Z-NOMP let us know and we will list your website here.
 
-### Some pools using Z-NOMP or node-stratum-module:
+### Some BTCPrivate Pools:
 
-https://pool.cryptobroker.io/zcl Running MPOS and 0.5% of the fee goes to the Zclassic donation fund! 200+ blocks have been found as well! 
+https://btcp.ragnarpool.ovh/stats
 
-http://luckpool.org Zcash Pool with Custom Frontend w/Miner's Jackpot
-
-http://zclmine.com/ Custom frontend
-
-http://zclassic.miningspeed.com Custom frontend and 0% fee
-
-https://zpool.it 0.5% fee
-
-http://miningpool.io/
+https://btcp.coinblockers.com/
 
 Usage
 =====
@@ -57,9 +49,9 @@ you are using - a good place to start with redis is [data persistence](http://re
 Follow the build/install instructions for your coin daemon. Your coin.conf file should end up looking something like this:
 ```
 daemon=1
-rpcuser=zclassicrpc
+rpcuser=btcprivaterpc
 rpcpassword=securepassword
-rpcport=8232
+rpcport=7933
 ```
 For redundancy, its recommended to have at least two daemon instances running in case one drops out-of-sync or offline,
 all instances will be polled for block/transaction updates and be used for submitting blocks. Creating a backup daemon
@@ -80,14 +72,14 @@ Clone the repository and run `npm update` for all the dependencies to be install
 sudo apt-get install build-essential libsodium-dev npm
 sudo npm install n -g
 sudo n stable
-git clone https://github.com/joshuayabut/node-open-mining-portal.git z-nomp
+git clone https://github.com/BTCPrivate/z-nomp.git z-nomp
 cd z-nomp
 npm update
 npm install
 ```
 
 ##### Pool config
-Take a look at the example json file inside the `pool_configs` directory. Rename it to `zclassic.json` and change the
+Take a look at the example json file inside the `pool_configs` directory. Rename it to `BTCPrivate.json` and change the
 example fields to fit your setup.
 
 ```
@@ -105,9 +97,9 @@ ie: Miner 1 mines at 0.1 difficulty and finds 10 shares, the pool sees it as 1 s
 ```
 node [path to cli.js] [coin name in config] [block hash symbol]
 ```
-Example: inside `zclassic.conf` add the line
+Example: inside `btcprivate.conf` add the line
 ```
-blocknotify=node /home/user/z-nomp/scripts/cli.js blocknotify zclassic %s
+blocknotify=node /home/user/z-nomp/scripts/cli.js blocknotify btcprivate %s
 ```
 
 Alternatively, you can use a more efficient block notify script written in pure C. Build and usage instructions

--- a/coins/btcprivate.json
+++ b/coins/btcprivate.json
@@ -1,0 +1,8 @@
+{
+    "name": "btcprivate",
+    "symbol": "btcp",
+    "algorithm": "equihash",
+    "requireShielding": true,
+    "peerMagic": "",
+    "txfee": 0.0004
+}

--- a/coins/btcprivate_testnet.json
+++ b/coins/btcprivate_testnet.json
@@ -1,0 +1,8 @@
+{
+    "name": "btcprivate_testnet",
+    "symbol": "bttt",
+    "algorithm": "equihash",
+    "requireShielding": true,
+    "peerMagic": "",
+    "txfee": 0.0004
+}

--- a/libs/api.js
+++ b/libs/api.js
@@ -26,7 +26,7 @@ module.exports = function(logger, portalConfig, poolConfigs){
             case 'getblocksstats':
                 portalStats.getBlocks(function(data){
                     res.header('Content-Type', 'application/json');
-                    res.end(JSON.stringify(data));                                        
+                    res.end(JSON.stringify(data));
                 });
                 break;
             case 'payments':
@@ -52,7 +52,7 @@ module.exports = function(logger, portalConfig, poolConfigs){
 						// get miners balance along with worker balances
 						portalStats.getBalanceByAddress(address, function(balances) {
 							// get current round share total
-							portalStats.getTotalSharesByAddress(address, function(shares) {								
+							portalStats.getTotalSharesByAddress(address, function(shares) {
 								var totalHash = parseFloat(0.0);
 								var totalShares = shares;
 								var networkSols = 0;
@@ -103,6 +103,7 @@ module.exports = function(logger, portalConfig, poolConfigs){
 				}
                 return;
             case 'live_stats':
+            /*
                 res.writeHead(200, {
                     'Content-Type': 'text/event-stream',
                     'Cache-Control': 'no-cache',
@@ -115,6 +116,7 @@ module.exports = function(logger, portalConfig, poolConfigs){
                 req.on("close", function() {
                     delete _this.liveStatConnections[uid];
                 });
+                */
                 return;
             default:
                 next();

--- a/website/pages/stats.html
+++ b/website/pages/stats.html
@@ -318,7 +318,9 @@ legend.append('text')
 
 
 <script>
-	window.statsSource = new EventSource("/api/live_stats");
+  /* This will prevent client to listen live_stats */
+	//window.statsSource = new EventSource("/api/live_stats");
+  /*
     $(function() {
         statsSource.addEventListener('message', function (e) {
             var stats = JSON.parse(e.data);
@@ -337,7 +339,7 @@ legend.append('text')
             }
         });
     });
-
+  */
 	function getReadableNetworkHashRateString(hashrate){
 		hashrate = (hashrate * 1000000);
 		if (hashrate < 1000000)

--- a/website/static/miner_stats.js
+++ b/website/static/miner_stats.js
@@ -53,7 +53,7 @@ function buildChartData(){
 			workerHistoryMax = a.hashrate.length;
 		}
 	}
-	
+
 	var i=0;
     workerHashrateData = [];
     for (var worker in workers){
@@ -213,11 +213,12 @@ $.getJSON('/api/worker_stats?'+_miner, function(data){
 	for (var w in statData.workers) { _workerCount++; }
 	buildChartData();
 	displayCharts();
-	rebuildWorkerDisplay();	
+	rebuildWorkerDisplay();
     updateStats();
 });
 
 // live stat updates
+/*NO OPEN CHANNELS
 statsSource.addEventListener('message', function(e){
 	// TODO, create miner_live_stats...
 	// miner_live_stats will return the same josn except without the worker history
@@ -244,3 +245,4 @@ statsSource.addEventListener('message', function(e){
 		}
 	});
 });
+*/


### PR DESCRIPTION
Live stats removed to avoid memory leak

-  Event source removed from stats to prevent client to start listening to live_stats api

I also recommend to disable keep-alive param on the load balancer side.