### PR TITLE
PPLNT fix for multiple instances

### DIFF
--- a/init.js
+++ b/init.js
@@ -289,7 +289,7 @@ var spawnPoolWorkers = function(){
                         //var timeChangeTotal = roundTo(Math.max(now - lastStartTime, 0) / 1000, 4);
                         if (timeChangeSec < 900) {
                             // loyal miner keeps mining :)
-                            redisCommands.push(['hincrbyfloat', msg.coin + ':shares:timesCurrent', workerAddress, timeChangeSec]);                            
+                            redisCommands.push(['hincrbyfloat', msg.coin + ':shares:timesCurrent', workerAddress + "." + poolConfigs[msg.coin].poolId, timeChangeSec]);                            
                             //logger.debug('PPLNT', msg.coin, 'Thread '+msg.thread, workerAddress+':{totalTimeSec:'+timeChangeTotal+', timeChangeSec:'+timeChangeSec+'}');
                             connection.multi(redisCommands).exec(function(err, replies){
                                 if (err)

--- a/libs/stats.js
+++ b/libs/stats.js
@@ -616,12 +616,10 @@ module.exports = function(logger, portalConfig, poolConfigs){
                 }
                 for (var worker in coinStats.currentRoundTimes) {
                     var time = parseFloat(coinStats.currentRoundTimes[worker]);
-                    if (_maxTimeShare < time)
-                        _maxTimeShare = time;
-                    
-                    var miner = worker.split(".")[0];
-                    if (miner in coinStats.miners) {
-                        coinStats.miners[miner].currRoundTime += parseFloat(coinStats.currentRoundTimes[worker]);
+                    if (_maxTimeShare < time) { _maxTimeShare = time; }
+                    var miner = worker.split(".")[0];	// split poolId from minerAddress
+                    if (miner in coinStats.miners && coinStats.miners[miner].currRoundTime < time) {
+                        coinStats.miners[miner].currRoundTime = time;
                     }
                 }
 
@@ -636,6 +634,10 @@ module.exports = function(logger, portalConfig, poolConfigs){
 					coinStats.workers[worker].luckHours = ((_networkHashRate / _wHashRate * _blocktime) / (60 * 60)).toFixed(3);
 					coinStats.workers[worker].hashrate = _workerRate;
 					coinStats.workers[worker].hashrateString = _this.getReadableHashRateString(_workerRate);
+					var miner = worker.split('.')[0];
+					if (miner in coinStats.miners) {
+						coinStats.workers[worker].currRoundTime = coinStats.miners[miner].currRoundTime;
+					}
                 }
 				for (var miner in coinStats.miners) {
 					var _workerRate = shareMultiplier * coinStats.miners[miner].shares / portalConfig.website.stats.hashrateWindow;

--- a/pool_configs/zen_example.json
+++ b/pool_configs/zen_example.json
@@ -54,6 +54,9 @@
             }
         }
     },
+    
+    "poolId": "main",
+    "_comment_poolId": "use it for region identification: eu, us, asia or keep default if you have one stratum instance for one coin",
 
     "daemons": [
         {


### PR DESCRIPTION
There is a known issue about "mining time" when you have multiple z-nomp instances (usually for regional stratums) working against one redis.
If one miner (with same address) will mine on two or many pool instances all PPLNT system will be broken:
- Wrong maxTime for the round (it will be higher than real time);
- All miners could be affected by < 51% mining time without real violation of PPLNT rules;

Commit also fixes "0" currRoundTime in worker_stats api.

This is important fix for pools with PPLNT turned on and have multiple z-nomp instances working with one redis database in same time.